### PR TITLE
Support MacOS 15 and remove 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-13, macos-14]
+        os: [ubuntu-22.04, macos-13, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
MacOS 12 is being removed by Github and therefore we can't provide pre-compiled binaries for it anymore, but 15 is now available so we can add that. Users will still be able to compile it locally.