### PR TITLE
Update formula for new version scheme

### DIFF
--- a/Formula/overmind-cli.rb
+++ b/Formula/overmind-cli.rb
@@ -16,13 +16,8 @@ class OvermindCli < Formula
   depends_on "go" => :build
 
   def install
-    # Write the version of the package to an embedded file so that previous
-    # versions can be compiled.
-    File.write("tracing/commit.txt", "v#{version}-brew")
-    File.write("cmd/commit.txt", "v#{version}-brew")
-
     # Compile the correct version into the binary
-    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/overmindtech/cli/tracing.ServiceVersion=v#{version}-brew", output: "overmind")
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/overmindtech/cli/tracing.version=v#{version}-brew", output: "overmind")
 
     bin.install "overmind"
   end


### PR DESCRIPTION
Now everything is driven through `tracing.version`, no commit.txt required anymore.