### PR TITLE
Bump overmindtech/cli formula immediately on new releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
   "packageRules": [
     {
       "matchPackageNames": ["overmindtech/cli"],
-      "automerge": false
+      "automerge": false,
+      "schedule": ["at any time"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

The base [renovate-config schedule](https://github.com/overmindtech/renovate-config/blob/main/schedule.json) limits branch creation to Friday mornings (Europe/London) to avoid noisy dependency PRs across the org. That makes sense for most deps, but it also means that after a CLI release the homebrew bump sits in the Dependency Dashboard until Friday — which is what blocked [ENG-3989](https://linear.app/overmind/issue/ENG-3989/release-the-cli-tool) for `v1.18.0`.

This adds a per-package override so the `overmindtech/cli` formula PR opens as soon as Renovate sees the new GitHub release, matching what someone running ``brew install overmindtech/overmind/overmind-cli`` would expect after a release.

```diff
     {
       "matchPackageNames": ["overmindtech/cli"],
-      "automerge": false
+      "automerge": false,
+      "schedule": ["at any time"]
     }
```

The rest of the renovate-config schedule (frontend, Go modules, GitHub Actions, etc.) is unchanged — only this single formula bypasses the Friday window.

## Test plan

- [ ] Merge this, then wait for renovate to open the PR on the next run
- [ ] Run the standard `pr-pull` flow on that PR and verify v1.18.0 bottles ship

Refs ENG-3989.

Made with [Cursor](https://cursor.com)