### PR TITLE
fix(ci): use ubuntu-24.04 for brew test-bot Linux matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,8 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14, macos-15]
+        # Homebrew 6.x brew doctor rejects glibc 2.35 on ubuntu-22.04 (Tier 2).
+        os: [ubuntu-24.04, macos-14, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
## Summary

Bumps the Linux matrix runner from `ubuntu-22.04` to `ubuntu-24.04` in the brew test-bot workflow.

Homebrew 6.0.1 `brew doctor` now fails on ubuntu-22.04 because glibc 2.35 is below the current Tier 2 minimum. This blocked [PR #140](https://github.com/overmindtech/homebrew-overmind/pull/140) (overmind-cli v1.18.5) before formula build/test ran.

## Test plan

- [ ] Merge this PR
- [ ] Re-run brew test-bot on [PR #140](https://github.com/overmindtech/homebrew-overmind/pull/140) (or wait for Renovate to rebase it onto main)
- [ ] Add `pr-pull` label when bottling goes green


Made with [Cursor](https://cursor.com)